### PR TITLE
Add GitHub Skills activity to extracurricular activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub - part of the GitHub Certifications program to help with college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the missing GitHub Skills activity that was announced by the principal in the school assembly.

## Changes
- Added GitHub Skills activity to the activities list in `src/app.py`
- Activity includes information about the GitHub Certifications program
- Schedule: Wednesdays, 3:30 PM - 5:00 PM
- Maximum 25 participants

## Context
Students reported they couldn't find the GitHub Skills activity on the signup page despite the principal's announcement. This is time-sensitive as registrations close at the end of the week.

Fixes #6